### PR TITLE
Modify bubble sort syntax that the ADLI tool does not support.

### DIFF
--- a/workers/bubbleSort/bubbleSort.py
+++ b/workers/bubbleSort/bubbleSort.py
@@ -8,7 +8,10 @@ def bubble_sort(arr):
             if arr[i] > arr[i + 1]:
 
                 # Swap elements if they are in the wrong order
-                arr[i], arr[i + 1] = arr[i + 1], arr[i]
+                temp1 = arr[i + 1]
+                temp2 = arr[i]
+                arr[i] = temp1
+                arr[i + 1] = temp2
                 swapped = True
         
         if not swapped:


### PR DESCRIPTION
This PR changes the bubble sort syntax because the ADLI tool is incorrectly extracting variable name from this statement:

```
arr[i], arr[i + 1] = arr[i + 1], arr[i]

# gets incorrectly logged as 
asp_temp_var_589bb3fa13d011f0aeb63b7083804bc7 = i + 1
aspAdliVarLog((arr[i], arr[asp_temp_var_589bb3fa13d011f0aeb63b7083804bc7]), 23)

#with the variable info being

{
        "varId": 23,
        "name": "arr",
        "keys": [
            {
                "type": "variable",
                "value": "i"
            },
            {
                "type": "variable",
                "value": "arr"
            },
            {
                "type": "temp_variable",
                "value": "asp_temp_var_589bb3fa13d011f0aeb63b7083804bc7"
            }
        ],
        "logType": 51,
        "funcId": 46,
        "isTemp": false,
        "global": false
}
```

This is incorrect and each variable should be logged on its own. I was initially confused because I do process each target in the assign statement separately but when I looked at the injected source, I found when the AST was unparsed, the statement was modified as follows:

```
arr[i], arr[i + 1] = arr[i + 1], arr[i]

#became

(arr[i], arr[asp_temp_var_589bb3fa13d011f0aeb63b7083804bc7]) = (arr[i + 1], arr[i])
```
This caused ADLI to treat the tuple as a single target and log it, resulting in the incorrect keys and variable logging. So the ADLI tool needs to treat entries in a tuple as separate targets.

When support is added in the ADLI tool, the syntax can be reverted back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Refined the element swapping operation within our sorting functionality to enhance internal clarity without affecting overall behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->